### PR TITLE
Fix Tribute duplicate payment error

### DIFF
--- a/db/dal/payment_dal.py
+++ b/db/dal/payment_dal.py
@@ -46,6 +46,15 @@ async def get_payment_by_yookassa_id(
     return result.scalar_one_or_none()
 
 
+async def get_payment_by_provider_payment_id(
+        session: AsyncSession, provider_payment_id: str) -> Optional[Payment]:
+    """Fetch a payment by provider-specific identifier."""
+    stmt = select(Payment).where(
+        Payment.provider_payment_id == provider_payment_id)
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
 async def get_payment_by_db_id(session: AsyncSession,
                                payment_db_id: int) -> Optional[Payment]:
 


### PR DESCRIPTION
## Summary
- add helper to fetch payments by provider ID
- skip creating duplicate Tribute payment records

## Testing
- `python -m py_compile bot/services/tribute_service.py db/dal/payment_dal.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db8230d888321a8bb85404af6287e