### PR TITLE
Support subscription mini app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ DEFAULT_CURRENCY_SYMBOL="RUB"  # e.g., RUB, USD, EUR
 SUPPORT_LINK=https://t.me/your_support_link
 SERVER_STATUS_URL=https://status.yourdomain.tld/status/your_service
 TERMS_OF_SERVICE_URL=https://example.com/tos
+SUBSCRIPTION_MINI_APP_URL=
 
 # YooKassa Payment Gateway Configuration
 YOOKASSA_SHOP_ID=your_shop_id

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This Telegram bot is designed to automate the sale and management of subscriptio
     * `DEFAULT_CURRENCY_SYMBOL`: e.g., `RUB`, `USD`.
     * `SUPPORT_LINK`: (Optional) URL for a support chat/contact (e.g., `https://t.me/your_support`).
     * `SERVER_STATUS_URL`: (Optional) URL to a server status page (e.g., Uptime Kuma).
+    * `SUBSCRIPTION_MINI_APP_URL`: (Optional) URL of the Telegram mini app for viewing subscription details. If set, the "My Subscription" button will open this mini app and the bot will register it automatically via API.
     * **YooKassa Settings:**
         * `YOOKASSA_SHOP_ID`: Your shop ID from YooKassa.
         * `YOOKASSA_SECRET_KEY`: Your secret key from YooKassa.

--- a/bot/keyboards/inline/user_keyboards.py
+++ b/bot/keyboards/inline/user_keyboards.py
@@ -1,5 +1,5 @@
 from aiogram.utils.keyboard import InlineKeyboardBuilder, InlineKeyboardButton
-from aiogram.types import InlineKeyboardMarkup
+from aiogram.types import InlineKeyboardMarkup, WebAppInfo
 from typing import Dict, Optional, List
 
 from config.settings import Settings
@@ -21,9 +21,20 @@ def get_main_menu_inline_keyboard(
     builder.row(
         InlineKeyboardButton(text=_(key="menu_subscribe_inline"),
                              callback_data="main_action:subscribe"))
-    builder.row(
-        InlineKeyboardButton(text=_(key="menu_my_subscription_inline"),
-                             callback_data="main_action:my_subscription"))
+    if settings.SUBSCRIPTION_MINI_APP_URL:
+        builder.row(
+            InlineKeyboardButton(
+                text=_(key="menu_my_subscription_inline"),
+                web_app=WebAppInfo(url=settings.SUBSCRIPTION_MINI_APP_URL),
+            )
+        )
+    else:
+        builder.row(
+            InlineKeyboardButton(
+                text=_(key="menu_my_subscription_inline"),
+                callback_data="main_action:my_subscription",
+            )
+        )
 
     referral_button = InlineKeyboardButton(
         text=_(key="menu_referral_inline"),

--- a/bot/main_bot.py
+++ b/bot/main_bot.py
@@ -3,7 +3,7 @@ import asyncio
 from typing import Callable, Dict, Any, Awaitable, Optional
 
 from aiogram import Bot, Dispatcher, BaseMiddleware, Router, F
-from aiogram.types import Update
+from aiogram.types import Update, MenuButtonWebApp, WebAppInfo
 from aiogram.enums import ParseMode
 from aiogram.filters import CommandStart, Command
 from aiogram.client.default import DefaultBotProperties
@@ -170,6 +170,14 @@ async def on_startup_configured(dispatcher: Dispatcher):
             "STARTUP: TELEGRAM_WEBHOOK_BASE_URL not set in environment. Attempting to delete any existing webhook (running in polling mode)."
         )
         await bot.delete_webhook(drop_pending_updates=True)
+
+    if settings.SUBSCRIPTION_MINI_APP_URL:
+        menu_text = i18n_instance.gettext(settings.DEFAULT_LANGUAGE, "menu_my_subscription_inline")
+        try:
+            await bot.set_chat_menu_button(menu_button=MenuButtonWebApp(text=menu_text, web_app=WebAppInfo(url=settings.SUBSCRIPTION_MINI_APP_URL)))
+            logging.info("STARTUP: Menu button for subscription mini app set via API.")
+        except Exception as e:
+            logging.error(f"STARTUP: Failed to set menu button web app: {e}", exc_info=True)
 
     logging.info("STARTUP: Bot on_startup_configured completed.")
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -101,6 +101,8 @@ class Settings(BaseSettings):
     WEB_SERVER_PORT: int = Field(default=8080)
     LOGS_PAGE_SIZE: int = Field(default=10)
 
+    SUBSCRIPTION_MINI_APP_URL: Optional[str] = Field(default=None)
+
     @computed_field
     @property
     def DATABASE_URL(self) -> str:


### PR DESCRIPTION
## Summary
- add SUBSCRIPTION_MINI_APP_URL setting
- open mini app instead of callback when URL is set
- register mini app button via Telegram API at startup
- document new setting

## Testing
- `python -m py_compile main.py bot/main_bot.py bot/keyboards/inline/user_keyboards.py config/settings.py`

------
https://chatgpt.com/codex/tasks/task_e_6867d9ddbe688321ba32237d5b13efa5