### PR TITLE
Enable mini app via API without menu change

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ SUPPORT_LINK=https://t.me/your_support_link
 SERVER_STATUS_URL=https://status.yourdomain.tld/status/your_service
 TERMS_OF_SERVICE_URL=https://example.com/tos
 SUBSCRIPTION_MINI_APP_URL=
+START_COMMAND_DESCRIPTION=
 
 # YooKassa Payment Gateway Configuration
 YOOKASSA_SHOP_ID=your_shop_id

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This Telegram bot is designed to automate the sale and management of subscriptio
     * `SUPPORT_LINK`: (Optional) URL for a support chat/contact (e.g., `https://t.me/your_support`).
     * `SERVER_STATUS_URL`: (Optional) URL to a server status page (e.g., Uptime Kuma).
     * `SUBSCRIPTION_MINI_APP_URL`: (Optional) URL of the Telegram mini app for viewing subscription details. If set, the "My Subscription" button will open this mini app and the bot will register it automatically via API.
+    * `START_COMMAND_DESCRIPTION`: (Optional) Description for the `/start` command shown in the bot's menu.
     * **YooKassa Settings:**
         * `YOOKASSA_SHOP_ID`: Your shop ID from YooKassa.
         * `YOOKASSA_SECRET_KEY`: Your secret key from YooKassa.

--- a/bot/main_bot.py
+++ b/bot/main_bot.py
@@ -3,7 +3,7 @@ import asyncio
 from typing import Callable, Dict, Any, Awaitable, Optional
 
 from aiogram import Bot, Dispatcher, BaseMiddleware, Router, F
-from aiogram.types import Update, MenuButtonWebApp, WebAppInfo
+from aiogram.types import Update, MenuButtonDefault, BotCommand
 from aiogram.enums import ParseMode
 from aiogram.filters import CommandStart, Command
 from aiogram.client.default import DefaultBotProperties
@@ -172,12 +172,20 @@ async def on_startup_configured(dispatcher: Dispatcher):
         await bot.delete_webhook(drop_pending_updates=True)
 
     if settings.SUBSCRIPTION_MINI_APP_URL:
-        menu_text = i18n_instance.gettext(settings.DEFAULT_LANGUAGE, "menu_my_subscription_inline")
         try:
-            await bot.set_chat_menu_button(menu_button=MenuButtonWebApp(text=menu_text, web_app=WebAppInfo(url=settings.SUBSCRIPTION_MINI_APP_URL)))
-            logging.info("STARTUP: Menu button for subscription mini app set via API.")
+            await bot.set_chat_menu_button(MenuButtonDefault())
+            logging.info("STARTUP: Mini app support enabled with default menu button.")
         except Exception as e:
-            logging.error(f"STARTUP: Failed to set menu button web app: {e}", exc_info=True)
+            logging.error(f"STARTUP: Failed to set default menu button: {e}", exc_info=True)
+
+    if settings.START_COMMAND_DESCRIPTION:
+        try:
+            await bot.set_my_commands([
+                BotCommand(command="start", description=settings.START_COMMAND_DESCRIPTION)
+            ])
+            logging.info("STARTUP: /start command description set.")
+        except Exception as e:
+            logging.error(f"STARTUP: Failed to set bot commands: {e}", exc_info=True)
 
     logging.info("STARTUP: Bot on_startup_configured completed.")
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -103,6 +103,8 @@ class Settings(BaseSettings):
 
     SUBSCRIPTION_MINI_APP_URL: Optional[str] = Field(default=None)
 
+    START_COMMAND_DESCRIPTION: Optional[str] = Field(default=None)
+
     @computed_field
     @property
     def DATABASE_URL(self) -> str:


### PR DESCRIPTION
## Summary
- add optional description for `/start` command
- keep default menu button while enabling mini-app
- document new `START_COMMAND_DESCRIPTION` variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867f1e328188321bd2ecb35e9309a89