### PR TITLE
Добавление файла .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -90,6 +90,3 @@ venv/
 
 # VS Code
 .vscode/
-
-# We are passing locales with docker volume anyway
-locales/


### PR DESCRIPTION
Позволяет не копировать в докер образ то, что не нужно для его работы.
Разница в финальном размере не такая существенная, но так мы удостоверимся что там точно нет ничего лишнего, например при сборке на моей локальной машине туда добавлялась директория `venv`

Сравнение файлов внутри образов:
<img width="1920" height="1080" alt="250908_19h49m39s_screenshot" src="https://github.com/user-attachments/assets/ad59ced9-8deb-4776-8a71-c5190387f96f" />

Сравнение размеров:
<img width="1920" height="1080" alt="250908_20h00m32s_screenshot" src="https://github.com/user-attachments/assets/5cb708ac-6e86-4392-893c-7cb58db2e385" />

Образы были собраны локально через podman
