### PR TITLE
An example Docker file for deploying a bot on a separate server

### DIFF
--- a/docker-compose-removed-server.yml
+++ b/docker-compose-removed-server.yml
@@ -6,7 +6,7 @@ services:
     env_file:
       - .env
     ports:
-      - 10000:10000
+      - 8080:8080
     networks:
       - remnawave-network
     environment:


### PR DESCRIPTION
You can use this example to deploy the bot on a separate server, the other settings are identical. This might be useful for reducing the load on the main server or for testing.